### PR TITLE
🛒 사용자 프로필 페이지에 구매 내역 탭 추가

### DIFF
--- a/accounts/templates/accounts/profile.html
+++ b/accounts/templates/accounts/profile.html
@@ -54,6 +54,9 @@
                 <a href="#account" class="tab-link text-indigo-600 border-b-2 border-indigo-600 py-4 px-6 font-medium text-sm">
                     계정 정보
                 </a>
+                <a href="#purchase-history" class="tab-link text-gray-500 hover:text-gray-700 py-4 px-6 font-medium text-sm">
+                    구매 내역
+                </a>    
             </nav>
         </div>
         
@@ -109,6 +112,72 @@
                 </div>
             </div>
         </section>
+        <!-- 구매 내역 섹션 -->
+        <section id="purchase-history" class="tab-content p-6 hidden">
+            <h2 class="text-xl font-semibold mb-4">구매 내역</h2>
+            
+            {% if purchases %}
+                <div class="space-y-4">
+                    {% for purchase in purchases %}
+                        <div class="bg-white rounded-lg shadow-md p-6 border border-gray-200 flex justify-between items-center">
+                            <div>
+                                <h3 class="text-lg font-semibold text-gray-900">{{ purchase.course.title }}</h3>
+                                <p class="text-sm text-gray-600 mt-1">
+                                    구매일: {{ purchase.purchase_date|date:"Y년 m월 d일" }}
+                                </p>
+                            </div>
+                            <div class="text-right">
+                                <p class="text-lg font-bold text-gray-900">
+                                    {{ purchase.price|floatformat:0 }}원
+                                </p>
+                                <span class="inline-block mt-1 px-2 py-1 bg-green-100 text-green-800 rounded-full text-xs">
+                                    {{ purchase.status }}
+                                </span>
+                            </div>
+                        </div>
+                    {% endfor %}
+                </div>
+            {% else %}
+                <div class="bg-gray-50 rounded-lg p-8 text-center">
+                    <p class="text-gray-600 mb-4">아직 구매한 과정이 없습니다.</p>
+                    <a href="{% url 'course_list' %}" class="inline-block px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded transition duration-200">
+                        과정 둘러보기
+                    </a>
+                </div>
+            {% endif %}
+        </section>
     </div>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const tabLinks = document.querySelectorAll('.tab-link');
+    const tabContents = document.querySelectorAll('.tab-content');
+
+    tabLinks.forEach(link => {
+      link.addEventListener('click', function(e) {
+        e.preventDefault();
+        
+        // 모든 탭 링크와 컨텐츠의 상태 초기화
+        tabLinks.forEach(l => {
+          l.classList.remove('text-indigo-600', 'border-b-2', 'border-indigo-600');
+          l.classList.add('text-gray-500', 'hover:text-gray-700');
+        });
+
+        tabContents.forEach(content => {
+          content.classList.add('hidden');
+        });
+
+        // 클릭한 탭 활성화
+        this.classList.remove('text-gray-500', 'hover:text-gray-700');
+        this.classList.add('text-indigo-600', 'border-b-2', 'border-indigo-600');
+
+        const targetId = this.getAttribute('href').substring(1);
+        document.getElementById(targetId).classList.remove('hidden');
+      });
+    });
+  });
+</script>
 {% endblock %}

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -52,8 +52,22 @@ def signup_view(request):
 
 @login_required
 def profile_view(request):
+    # 임시 구매 내역 데이터 생성 (나중에 실제 결제 모델과 연동 필요)
+    from courses.models import Course
+
+    # 사용자가 구매한 과정 목록 (임시)
+    purchases = []
+    for course in Course.objects.all()[:3]:  # 최대 3개의 과정을 가져옴
+        purchases.append({
+            'course': course,
+            'purchase_date': course.created_at,
+            'price': course.price,
+            'status': '결제 완료'
+        })
+
     context = {
         'user': request.user,
+        'purchases': purchases,
     }
     return render(request, 'accounts/profile.html', context)
 


### PR DESCRIPTION
자세한 변경 사항:

프로필 템플릿에 구매 내역 탭 구현
구매 내역 섹션에 탐색 및 콘텐츠 추가
사용 가능한 경우 더미 구매 데이터 표시
구매 내역이 없는 경우 과정 탐색 버튼 표시

#49 