### PR TITLE
🐛 FIX: 과정 상세화면에서 navbar 동작 오류 수정

### DIFF
--- a/courses/templates/courses/course_detail/tab_nav.html
+++ b/courses/templates/courses/course_detail/tab_nav.html
@@ -15,7 +15,8 @@
 
 <script>
   document.addEventListener('DOMContentLoaded', function () {
-    const tabs = document.querySelectorAll('nav a');
+    const tabNav = document.querySelector('.border-b.border-gray-200 nav');
+    const tabs = tabNav.querySelectorAll('a');
     const sections = document.querySelectorAll('section[id]');
 
     function showSection(sectionId) {


### PR DESCRIPTION
#53 

과정 상세 화면 고유의 탭 - "과정 구성", "상세 정보", "수강평"에 대한 클릭 핸들러를 navbar의 각 버튼에 대해서까지 적용시켜버리는 문제가 있었음.