### PR TITLE
🐛 FIX: 다음 학습 아이템 찾는데 없으면 Enrollment 상태를 completed로 변경

### DIFF
--- a/learning/views.py
+++ b/learning/views.py
@@ -63,6 +63,8 @@ def resume_course(request, course_id):
     elif item_type == "project":
         return redirect("learning:submit_project", subject_id=item.id)
     else:  # 'completed'
+        enrollment.status = "completed"
+        enrollment.save()
         return redirect("courses:course_detail", course_id=course.id)
 
 
@@ -83,6 +85,11 @@ def next_item(request, lecture_id):
     elif item_type == "project":
         return redirect("learning:submit_project", subject_id=item.id)
     else:  # 'completed'
+        enrollment = get_object_or_404(
+            Enrollment, user=request.user, course=lecture.subject.course
+        )
+        enrollment.status = "completed"
+        enrollment.save()
         return redirect("courses:course_detail", course_id=item.id)
 
 


### PR DESCRIPTION
#110 
"이어서 학습하기" url로 이동하거나, 강의에서 다음 강의로 이동할때, 다음 학습 아이템이 없는 경우, 
 Enrollment 상태를 completed로 변경하도록 했습니다.