### PR TITLE
🐛 FIX: Dockerfile의 ENV 위치 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.13-slim
 
 WORKDIR /app
 
+# 환경변수 설정
+ENV DJANGO_SETTINGS_MODULE=config.settings.prod
+
 # 시스템 패키지 설치
 RUN apt-get update \
     && apt-get install -y --no-install-recommends gcc libpq-dev \
@@ -25,6 +28,3 @@ RUN pdm add gunicorn
 
 # 포트 설정
 EXPOSE 8000
-
-# 환경변수 설정
-ENV DJANGO_SETTINGS_MODULE=config.settings.prod


### PR DESCRIPTION
#134 
ENV의 위치가 `RUN pdm run python manage.py collectstatic --noinput` 보다 아래쪽에 있는 문제가 있었음